### PR TITLE
Fix IO#scanf on pipes on Windows

### DIFF
--- a/lib/scanf.rb
+++ b/lib/scanf.rb
@@ -660,7 +660,7 @@ class IO
 
     begin
       seek(start_position + matched_so_far, IO::SEEK_SET)
-    rescue Errno::ESPIPE
+    rescue Errno::ESPIPE, Errno::EINVAL
     end
 
     soak_up_spaces if fstr.last_spec && fstr.space

--- a/test/scanf/test_scanfio.rb
+++ b/test/scanf/test_scanfio.rb
@@ -17,5 +17,12 @@ class TestScanfIO < Test::Unit::TestCase
   ensure
     fh.close
   end
+
+  def test_pipe_scanf
+    r, w = IO.pipe
+    w.write('a')
+    w.close
+    assert_equal([], r.scanf('a'))
+  end
 end
 


### PR DESCRIPTION
IO.seek on a pipe on Windows raises Errno::EINVAL instead of
Errno::ESPIPE.

Fixes Ruby Bug #15199