### PR TITLE
Include README, LICENSE and test files in gem

### DIFF
--- a/scanf.gemspec
+++ b/scanf.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ruby/scanf"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = ["lib/scanf.rb"]
+  spec.files         = ["lib/scanf.rb", "LICENSE.txt", "README.md"] + Dir["test/scanf/**"]
   spec.bindir        = "exe"
   spec.executables   = []
   spec.require_paths = ["lib"]


### PR DESCRIPTION
Currently I'm [working on packaging this gem for Fedora](https://bugzilla.redhat.com/bugzilla/show_bug.cgi?id=2077088) and Fedora guidelines state that the Fedora package should include the license, some documentation and have tests. The gem does not include these files, while the repository does. This changes the gemspec to include these files in the final gem.